### PR TITLE
chore: wlogout dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -22,7 +22,6 @@ depends=(
     'grim' # screenshot tool
     'slurp' # helper for grim
     'wob' # wayland overlay bar for brightness and volume
-    'wlogout' # nice logout menu
     'noto-fonts-emoji' # emoji font
     'foot' # terminal application
     'nerd-fonts-roboto-mono' # default monospace font


### PR DESCRIPTION
We've switched to use Sway mode to perform logout actions, so wlogout is not needed anymore.