### PR TITLE
fix: pull in the packages the lxqt file chooser actually needs

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=manjaro-sway-settings
 pkgver=17.2.3
-pkgrel=11
+pkgrel=12
 arch=('any')
 _pkgbase=desktop-settings
 url="https://github.com/Manjaro-Sway/$_pkgbase"
@@ -43,7 +43,11 @@ depends=(
     'dex'               # executes desktop entries on autostart
     'swaybg'            # wallpaper setter
     'rofimoji'          # emoji picker
+    ## portal
+    'xdg-desktop-portal-lxqt' # native lxqt file chooser, via the portal
+    'lxqt-qtplugin'           # styles the portal dialog process (qt6-only, that process only)
     ## theme
+    'qt6ct'                   # provides qt6ct-style, used to style the portal dialog
     'kvantum'                 # theme engine for qt
     'kvantum-qt5'             # theme engine for qt (qt 5 support)
     'ttf-jetbrains-mono-nerd' # default monospace font


### PR DESCRIPTION
Packaging half of manjaro-sway/manjaro-sway#999. Companion to manjaro-sway/desktop-settings#241.

The skel has asked for native lxqt file dialogs since d80bdda in desktop-settings, but none of the packages that implement them were ever added here, so the feature never worked and Qt theming broke along with it. The `-git` PKGBUILD grew them at the time — they were simply never backported to stable.

## What each one is for

**`xdg-desktop-portal-lxqt`** — the FileChooser implementation behind the `FileChooser=lxqt` preference in `sway-portals.conf`.

**`lxqt-qtplugin`** — needed by exactly one process. The portal backend is started with the platform theme hardcoded into its D-Bus activation line:

```
Exec=/bin/sh -c 'QT_QPA_PLATFORMTHEME=lxqt exec /usr/lib/xdg-desktop-portal-lxqt'
```

so without the plugin the dialog appears but renders unstyled. It is **not** the platform theme for applications — it ships `usr/lib/qt6/plugins/platformthemes/libqtlxqt.so` and nothing for Qt5, which is exactly what broke Qt5 apps in the first place.

Worth noting upstream: `xdg-desktop-portal-lxqt` depends on `qt6-base kwindowsystem xdg-desktop-portal libfm-qt` and *not* on `lxqt-qtplugin`, despite hardcoding its platform theme. Arguably an Arch packaging bug in its own right.

**`qt6ct`** — provides `qt6ct-style`, which skel `lxqt.conf` selects to style that same backend.

`qt5ct` is deliberately **not** added. With the portal platform theme in use no application reads the qtXct configs any more, and Kvantum carries the widget style for Qt5 and Qt6 alike.

## Sequencing

Inert on its own — the skel still says `QT_QPA_PLATFORMTHEME=lxqt` until desktop-settings#241 is merged **and tagged**. `set-version.yml` updates `pkgver`/`_sourcemd5` automatically on release, so only `pkgrel` is touched here (11 → 12), so the dependency change reaches users even if merged ahead of a release.

## Checks

`bash -n` passes, `depends` sources cleanly at 44 entries, and every added package resolves in `extra`: `xdg-desktop-portal-lxqt 1.4.0-1`, `lxqt-qtplugin 2.4.0-3`, `qt6ct 0.11-8`.

## Follow-up, not done here

`skel/.config/qt5ct/qt5ct.conf` becomes inert under this design. Left in place to keep the diff focused — happy to remove it separately if you'd rather not carry a dead config.
